### PR TITLE
Add support for Meeco subscription keys MEE-324

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Note - because the API SDK's are not currently publicly published, the `.npmrc.g
 
 After cloning the repo, run `npm install` to install dependencies.
 
+## The `meeco` command
+
+If you want to run `meeco <command>` and have it point to your dev environment - run `npm link .` to hook up a global `meeco` to the current workspace.
+
+Alternatively, just run `./bin/meeco` when developing
+
 # Usage
 
 ```sh-session
@@ -433,14 +439,17 @@ spec:
 
 ```yaml
 vault:
-  url: https://api-sandbox-test.meeco.me
+  url: https://sandbox.meeco.me/vault
+  subscription_key: my_api_subscription_key
 keystore:
-  url: https://keystore-sandbox-test.meeco.me
-  provider_api_key: my_provider_api_key
+  url: https://sandbox.meeco.me/keystore
+  subscription_key: my_api_subscription_key
 downloader:
-  url: https://downloader-sandbox-test.meeco.me
+  url: https://sandbox.meeco.me/downloader
+  subscription_key: my_api_subscription_key
 passphrase:
-  url: https://passphrasestore-sandbox-test.meeco.me
+  url: https://sandbox.meeco.me/passphrasestore
+  subscription_key: my_api_subscription_key
 ```
 
 ## Item

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "bugs": "https://github.com/Meeco/cli/issues",
   "dependencies": {
     "@meeco/cryppo": "~0.3.3",
-    "@meeco/meeco-api-sdk": "0.3.0-20200310-170636-99acaf5",
-    "@meeco/meeco-keystore-sdk": "0.8.0-20200306-103720-d73d7d6-sandbox",
+    "@meeco/meeco-api-sdk": "0.3.0-20200317-091501-ec77e6e6",
+    "@meeco/meeco-keystore-sdk": "0.8.0-20200317-091014-3d3ffaf-sandbox",
     "@meeco/meeco-passphrasestore-sdk": "0.8.0-20191108-141359-e2bb2dc",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -1,13 +1,16 @@
 export interface IEnvironment {
   vault: {
     url: string;
+    subscription_key: string;
   };
   keystore: {
     url: string;
+    subscription_key: string;
     provider_api_key: string;
   };
   passphrase: {
     url: string;
+    subscription_key: string;
   };
   downloader: {
     url: string;

--- a/src/services/share-service.ts
+++ b/src/services/share-service.ts
@@ -1,6 +1,5 @@
 import * as cryppo from '@meeco/cryppo';
-import * as VaultAPI from '@meeco/meeco-api-sdk';
-import * as KeyStoreAPI from '@meeco/meeco-keystore-sdk';
+import { Connection } from '@meeco/meeco-api-sdk';
 import { CLIError } from '@oclif/errors';
 import { AuthConfig } from '../configs/auth-config';
 import { EncryptionSpaceConfig } from '../configs/encryption-space-config';
@@ -10,6 +9,12 @@ import { EncryptionKey } from '../models/encryption-key';
 import { IEnvironment } from '../models/environment';
 import { LocalSlot } from '../models/local-slot';
 import { findConnectionBetween } from '../util/ find-connection-between';
+import {
+  KeystoreAPIFactory,
+  keystoreAPIFactory,
+  vaultAPIFactory,
+  VaultAPIFactory
+} from '../util/api-factory';
 import { ItemService } from './item-service';
 
 interface ISharedEncryptionSpace {
@@ -19,7 +24,13 @@ interface ISharedEncryptionSpace {
 }
 
 export class ShareService {
-  constructor(private environment: IEnvironment, private log: (message: string) => void) {}
+  private keystoreApiFactory: KeystoreAPIFactory;
+  private vaultApiFactory: VaultAPIFactory;
+
+  constructor(private environment: IEnvironment, private log: (message: string) => void) {
+    this.keystoreApiFactory = keystoreAPIFactory(environment);
+    this.vaultApiFactory = vaultAPIFactory(environment);
+  }
 
   public async shareItem(fromUser: AuthConfig, toUser: AuthConfig, itemId: string) {
     const { fromUserConnection, toUserConnection } = await findConnectionBetween(
@@ -45,7 +56,7 @@ export class ShareService {
     );
 
     this.log('Sending shared data');
-    const shareResult = await this.vaultShareApi(fromUser).sharesPost({
+    const shareResult = await this.vaultApiFactory(fromUser).ShareApi.sharesPost({
       shares: [share]
     });
     return {
@@ -55,24 +66,18 @@ export class ShareService {
   }
 
   public async listShares(user: AuthConfig) {
-    const result = await new VaultAPI.ShareApi({
-      apiKey: user.vault_access_token,
-      basePath: this.environment.vault.url
-    }).sharesGet();
+    const result = await this.vaultApiFactory(user).ShareApi.sharesGet();
     return ShareListConfig.encodeFromResult(result);
   }
 
   public async getSharedItem(user: AuthConfig, itemId: string) {
-    const result = await new VaultAPI.ShareApi({
-      apiKey: user.vault_access_token,
-      basePath: this.environment.vault.url
-    })
-      .sharesIdGet(itemId)
+    const result = await this.vaultApiFactory(user)
+      .ShareApi.sharesIdGet(itemId)
       .then(shares => shares);
     const [item] = result.items;
     const [share] = result.shares;
     const slots = result.slots;
-    const space = await this.encryptionSpaceApi(user).encryptionSpacesIdGet(
+    const space = await this.keystoreApiFactory(user).EncryptionSpaceApi.encryptionSpacesIdGet(
       share.encryption_space_id
     );
     const decryptedSharedDataEncryptionKey = await cryppo.decryptWithKey({
@@ -94,7 +99,7 @@ export class ShareService {
     itemId: string,
     toUserId: string
   ) {
-    const item = await this.itemApi(fromUser).itemsIdGet(itemId);
+    const item = await this.vaultApiFactory(fromUser).ItemApi.itemsIdGet(itemId);
 
     if (!item) {
       throw new CLIError(`Item '${itemId}' not found`);
@@ -147,8 +152,8 @@ export class ShareService {
 
   public async fetchSharedEncryptionSpace(
     fromUser: AuthConfig,
-    fromUserConnection: VaultAPI.Connection,
-    toUserConnection: VaultAPI.Connection
+    fromUserConnection: Connection,
+    toUserConnection: Connection
   ): Promise<ISharedEncryptionSpace> {
     if (!fromUserConnection.encryption_space_id) {
       // Users have no shared encryption space
@@ -159,9 +164,9 @@ export class ShareService {
     }
 
     this.log('Fetching shared encryption key');
-    const sharedDataEncryptionKey = await this.encryptionSpaceApi(fromUser).encryptionSpacesIdGet(
-      fromUserConnection.encryption_space_id
-    );
+    const sharedDataEncryptionKey = await this.keystoreApiFactory(
+      fromUser
+    ).EncryptionSpaceApi.encryptionSpacesIdGet(fromUserConnection.encryption_space_id);
 
     const decryptedSharedDataEncryptionKey = await cryppo.decryptWithKey({
       serialized: sharedDataEncryptionKey.encryption_space_data_encryption_key
@@ -195,12 +200,15 @@ export class ShareService {
     });
 
     this.log('Updating connection encryption space');
-    await this.connectionApi(fromUser).connectionsConnectionIdEncryptionSpacePost(connection.id!, {
-      encryption_space_id: encryptionSpaceId
-    });
+    await this.vaultApiFactory(fromUser).ConnectionApi.connectionsConnectionIdEncryptionSpacePost(
+      connection.id!,
+      {
+        encryption_space_id: encryptionSpaceId
+      }
+    );
 
     this.log('Sending shared key');
-    const sharedKey = await this.sharedKeyApi(fromUser).sharedKeysPost({
+    const sharedKey = await this.keystoreApiFactory(fromUser).SharedKeyApi.sharedKeysPost({
       encrypted_key: shareableDataEncryptionKey.serialized,
       external_id: encryptionSpaceId,
       public_key: recipientPublicKey,
@@ -220,8 +228,8 @@ export class ShareService {
     const connection = await this.fetchConnectionWithId(toUser, connectionId);
     const encryptionSpaceId = connection.other_user_connection_encryption_space_id!;
     this.log('Fetching key pair');
-    const keyPair = await this.keyPairApi(toUser)
-      .keypairsIdGet(connection.key_store_keypair_id)
+    const keyPair = await this.keystoreApiFactory(toUser)
+      .KeypairApi.keypairsIdGet(connection.key_store_keypair_id)
       .then(res => res.keypair);
 
     const privateKey = await cryppo.decryptWithKey({
@@ -239,15 +247,20 @@ export class ShareService {
     );
 
     this.log('Creating new encryption space with re-encrypted claimed key');
-    const encryptionSpace = await this.encryptionSpaceApi(toUser).encryptionSpacesPost({
+    const encryptionSpace = await this.keystoreApiFactory(
+      toUser
+    ).EncryptionSpaceApi.encryptionSpacesPost({
       encrypted_serialized_key: reEncryptedDataEncryptionKey.serialized
     });
     const { encryption_space_id } = encryptionSpace.encryption_space_data_encryption_key!;
 
     this.log('Updating shared encryption space');
-    await this.connectionApi(toUser).connectionsConnectionIdEncryptionSpacePost(connectionId, {
-      encryption_space_id
-    });
+    await this.vaultApiFactory(toUser).ConnectionApi.connectionsConnectionIdEncryptionSpacePost(
+      connectionId,
+      {
+        encryption_space_id
+      }
+    );
 
     return {
       connection,
@@ -263,8 +276,8 @@ export class ShareService {
       key: user.key_encryption_key.key,
       strategy: cryppo.CipherStrategy.AES_GCM
     });
-    const encryptionSpace = await this.encryptionSpaceApi(user)
-      .encryptionSpacesPost({
+    const encryptionSpace = await this.keystoreApiFactory(user)
+      .EncryptionSpaceApi.encryptionSpacesPost({
         encrypted_serialized_key: encryptedDataEncryptionKey.serialized
       })
       .then(result => result.encryption_space_data_encryption_key);
@@ -284,13 +297,12 @@ export class ShareService {
     }
   ) {
     const signature = await this.buildClaimKeySignature(encryptionSpaceId, keyPair.privateKey);
-    const claimedKey = await this.sharedKeyApi(user).sharedKeysExternalIdClaimKeyPost(
-      encryptionSpaceId,
-      {
-        public_key: keyPair.publicKey,
-        request_signature: signature.serialized
-      }
-    );
+    const claimedKey = await this.keystoreApiFactory(
+      user
+    ).SharedKeyApi.sharedKeysExternalIdClaimKeyPost(encryptionSpaceId, {
+      public_key: keyPair.publicKey,
+      request_signature: signature.serialized
+    });
     const decryptedDataEncryptionKey = await cryppo.decryptSerializedWithPrivateKey({
       serialized: claimedKey.shared_key_claimed?.serialized_shared_key!,
       privateKeyPem: keyPair.privateKey
@@ -313,7 +325,9 @@ export class ShareService {
 
   private async fetchConnectionWithId(user: AuthConfig, connectionId: string) {
     this.log('Fetching connection');
-    const connectionResponse = await this.connectionApi(user).connectionsIdGet(connectionId);
+    const connectionResponse = await this.vaultApiFactory(user).ConnectionApi.connectionsIdGet(
+      connectionId
+    );
     const connection = connectionResponse.connection;
     if (!connection || !connection.id) {
       throw new CLIError(`Connection '${connectionId}' not found.`);
@@ -351,51 +365,5 @@ export class ShareService {
       encryptedSlots.reduce((prev, next) => ({ ...prev, ...next }), {})
     );
     return encrypted_values;
-  }
-
-  /**
-   * Helper methods for creating APIs from users
-   */
-
-  private itemApi(user: AuthConfig) {
-    return new VaultAPI.ItemApi({
-      apiKey: user.vault_access_token,
-      basePath: this.environment.vault.url
-    });
-  }
-
-  private connectionApi(user: AuthConfig) {
-    return new VaultAPI.ConnectionApi({
-      apiKey: user.vault_access_token,
-      basePath: this.environment.vault.url
-    });
-  }
-
-  private vaultShareApi(user: AuthConfig) {
-    return new VaultAPI.ShareApi({
-      apiKey: user.vault_access_token,
-      basePath: this.environment.vault.url
-    });
-  }
-
-  private encryptionSpaceApi(user: AuthConfig) {
-    return new KeyStoreAPI.EncryptionSpaceApi({
-      apiKey: user.keystore_access_token,
-      basePath: this.environment.keystore.url
-    });
-  }
-
-  private keyPairApi(user: AuthConfig) {
-    return new KeyStoreAPI.KeypairApi({
-      apiKey: user.keystore_access_token,
-      basePath: this.environment.keystore.url
-    });
-  }
-
-  private sharedKeyApi(user: AuthConfig) {
-    return new KeyStoreAPI.SharedKeyApi({
-      apiKey: user.keystore_access_token,
-      basePath: this.environment.keystore.url
-    });
   }
 }

--- a/src/services/share-service.ts
+++ b/src/services/share-service.ts
@@ -1,5 +1,5 @@
 import * as cryppo from '@meeco/cryppo';
-import { Connection } from '@meeco/meeco-api-sdk';
+import { Connection, Share, Slot } from '@meeco/meeco-api-sdk';
 import { CLIError } from '@oclif/errors';
 import { AuthConfig } from '../configs/auth-config';
 import { EncryptionSpaceConfig } from '../configs/encryption-space-config';
@@ -76,7 +76,7 @@ export class ShareService {
       .then(shares => shares);
     const [item] = result.items;
     const [share] = result.shares;
-    const slots = result.slots;
+    const slots = this.addShareValuesToSlots(share, result.slots);
     const space = await this.keystoreApiFactory(user).EncryptionSpaceApi.encryptionSpacesIdGet(
       share.encryption_space_id
     );
@@ -90,6 +90,13 @@ export class ShareService {
       ...item,
       slots: decryptedSlots
     });
+  }
+
+  private addShareValuesToSlots(share: Share, slots: Slot[]) {
+    slots.forEach(slot => {
+      slot.encrypted_value = (share?.encrypted_values || {})[slot.id];
+    });
+    return slots;
   }
 
   private async shareItemFromVaultItem(

--- a/src/services/templates-service.ts
+++ b/src/services/templates-service.ts
@@ -2,15 +2,13 @@ import { ItemTemplateApi } from '@meeco/meeco-api-sdk';
 import { CLIError } from '@oclif/errors';
 import { TemplateConfig } from '../configs/template-config';
 import { IEnvironment } from '../models/environment';
+import { vaultAPIFactory } from '../util/api-factory';
 
 export class TemplatesService {
   private api: ItemTemplateApi;
 
   constructor(environment: IEnvironment, vaultAccessToken: string) {
-    this.api = new ItemTemplateApi({
-      basePath: environment.vault.url,
-      apiKey: vaultAccessToken
-    });
+    this.api = vaultAPIFactory(environment)(vaultAccessToken).ItemTemplateApi;
   }
 
   public async listTemplates(classificationScheme: string, classificationName: string) {

--- a/src/util/ find-connection-between.ts
+++ b/src/util/ find-connection-between.ts
@@ -1,13 +1,10 @@
-import * as VaultAPI from '@meeco/meeco-api-sdk';
 import { CLIError } from '@oclif/errors';
 import { AuthConfig } from '../configs/auth-config';
 import { IEnvironment } from '../models/environment';
+import { vaultAPIFactory } from './api-factory';
 
 function connectionApi(user: AuthConfig, environment: IEnvironment) {
-  return new VaultAPI.ConnectionApi({
-    apiKey: user.vault_access_token,
-    basePath: environment.vault.url
-  });
+  return vaultAPIFactory(environment)(user).ConnectionApi;
 }
 
 export async function findConnectionBetween(

--- a/src/util/api-factory.ts
+++ b/src/util/api-factory.ts
@@ -1,0 +1,154 @@
+import * as Vault from '@meeco/meeco-api-sdk';
+import * as Keystore from '@meeco/meeco-keystore-sdk';
+import { AuthConfig } from '../configs/auth-config';
+import { IEnvironment } from '../models/environment';
+
+/**
+ * User authentication token for the given API or the entire user with tokens
+ */
+type UserAuth = AuthConfig | string;
+
+type KeystoreAPIConstructor = new () => Keystore.BaseAPI;
+type VaultAPIConstructor = new () => Vault.BaseAPI;
+
+type KeysOfType<T, TProp> = { [P in keyof T]: T[P] extends TProp ? P : never }[keyof T];
+type VaultAPIName = KeysOfType<typeof Vault, VaultAPIConstructor>;
+type KeystoreAPIName = KeysOfType<typeof Keystore, KeystoreAPIConstructor>;
+
+const vaultToken = (userAuth: UserAuth) => {
+  return typeof userAuth === 'string' ? userAuth : userAuth.vault_access_token;
+};
+
+const keystoreToken = (userAuth: UserAuth) => {
+  return typeof userAuth === 'string' ? userAuth : userAuth.keystore_access_token;
+};
+
+/**
+ * Pluck environment and user auth values to create `apiKey` [Keystore.Configuration] parameter
+ */
+const keystoreAPIKeys = (environment: IEnvironment, userAuth: UserAuth) => (name: string) =>
+  ({
+    'Meeco-Subscription-Key': environment.keystore.subscription_key,
+    // Must be uppercase
+    // prettier-ignore
+    'Authorization': keystoreToken(userAuth)
+  }[name]);
+
+/**
+ * Pluck environment and user auth values to create `apiKey` [Vault.Configuration] parameter
+ */
+const vaultAPIKeys = (environment: IEnvironment, userAuth: UserAuth) => (name: string) =>
+  ({
+    'Meeco-Subscription-Key': environment.vault.subscription_key,
+    // Must be uppercase
+    // prettier-ignore
+    'Authorization': vaultToken(userAuth)
+  }[name]);
+
+/**
+ * Helper for constructing instances of Keystore apis with all the required auth params
+ */
+const keystoreAPI = (api: KeystoreAPIName, environment: IEnvironment, userAuth: UserAuth) => {
+  return new Keystore[api]({
+    apiKey: keystoreAPIKeys(environment, userAuth),
+    basePath: environment.keystore.url
+  }) as InstanceType<typeof Keystore[typeof api]>;
+};
+
+/**
+ * Helper for constructing instances of Vault apis with all the required auth params
+ */
+const vaultAPI = (api: VaultAPIName, environment: IEnvironment, userAuth: UserAuth) => {
+  return new Vault[api]({
+    apiKey: vaultAPIKeys(environment, userAuth),
+    basePath: environment.vault.url
+  }) as InstanceType<typeof Vault[typeof api]>;
+};
+
+/**
+ * Convenience for the various headers and parameters that need to be setup when constructing an API.
+ *
+ * It avoids a lot of boilerplate in constructing arguments for an api (api keys, subscription keys etc.)
+ *
+ * Basically, instead of
+ * ```ts
+ * new Keystore.EncryptionSpaceApi({
+ *  baseApi: environment.api.url,
+ *   apiKey: (key: string) => {
+ *    if(key === 'Meeco-Subscription-Key') return environment.keystore.subscription_key;
+ *    if(key === 'Authorization) return user.keystore_access_token
+ *   }
+ * }).someMethod();
+ * ```
+ *
+ * you can create a factory that returns these instances for you:
+ *
+ * ```ts
+ * const factory = keystoreAPIFactory(environment);
+ * const forUser = factory(userAuth);
+ * forUser.EncryptionSpaceApi.getItems();
+ * forUser.KeypairApi.getConnections();
+ * // etc...
+ * ```
+ */
+export type KeystoreAPIFactory = (userAuth: UserAuth) => KeystoreAPIFactoryInstance;
+type KeystoreAPIFactoryInstance = {
+  [key in KeystoreAPIName]: InstanceType<typeof Keystore[key]>;
+};
+
+/**
+ * Convenience for the various headers and parameters that need to be setup when constructing an API.
+ *
+ * It avoids a lot of boilerplate in constructing arguments for an api (api keys, subscription keys etc.)
+ *
+ * Basically, instead of
+ * ```ts
+ * new Vault.ItemApi({
+ *  baseApi: environment.api.url,
+ *   apiKey: (key: string) => {
+ *    if(key === 'Meeco-Subscription-Key') return environment.vault.subscription_key;
+ *    if(key === 'Authorization) return user.vault_access_token
+ *   }
+ * }).someMethod();
+ * ```
+ *
+ * you can create a factory that returns these instances for you:
+ *
+ * ```ts
+ * const factory = vaultAPIFactory(environment);
+ * const forUser = factory(userAuth);
+ * forUser.ItemsAPI.getItems();
+ * forUser.ConnectionAPI.getConnections();
+ * // etc...
+ * ```
+ */
+export type VaultAPIFactory = (userAuth: UserAuth) => VaultAPIFactoryInstance;
+type VaultAPIFactoryInstance = { [key in VaultAPIName]: InstanceType<typeof Vault[key]> };
+
+/**
+ * Results in a factory function that can be passed user auth information and then get
+ * arbitrary Keystore api instances to use.
+ */
+export const keystoreAPIFactory = (environment: IEnvironment) => (userAuth: UserAuth) =>
+  new Proxy(
+    {},
+    {
+      get(target, property: KeystoreAPIName) {
+        return keystoreAPI(property, environment, userAuth);
+      }
+    }
+  ) as KeystoreAPIFactoryInstance;
+
+/**
+ * Results in a factory function that can be passed user auth information and then get
+ * arbitrary Vault api instances to use.
+ */
+export const vaultAPIFactory = (environment: IEnvironment) => (userAuth: UserAuth) =>
+  new Proxy(
+    {},
+    {
+      get(target, property: VaultAPIName) {
+        return vaultAPI(property, environment, userAuth);
+      }
+    }
+  ) as VaultAPIFactoryInstance;

--- a/test/commands/connections/create.test.ts
+++ b/test/commands/connections/create.test.ts
@@ -8,8 +8,8 @@ describe('connections:create', () => {
     .stdout()
     .stderr()
     .mockCryppo()
-    .nock('https://api-sandbox.meeco.me', stubVault)
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
     .run([
       'connections:create',
       ...testEnvironmentFile,
@@ -38,6 +38,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'from_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -50,6 +51,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'to_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -79,6 +81,7 @@ function stubVault(api: nock.Scope) {
       public_key: '--PUBLIC_KEY--ABCD'
     })
     .matchHeader('Authorization', 'from_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       public_key: {
         id: 'from_public_key_id'
@@ -91,6 +94,7 @@ function stubVault(api: nock.Scope) {
       public_key: '--PUBLIC_KEY--ABCD'
     })
     .matchHeader('Authorization', 'to_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       public_key: {
         id: 'to_public_key_id'
@@ -108,6 +112,7 @@ function stubKeystore(api: nock.Scope) {
       external_identifiers: []
     })
     .matchHeader('Authorization', 'to_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       keypair: {
         id: 'to_stored_keypair_id'
@@ -123,6 +128,7 @@ function stubKeystore(api: nock.Scope) {
       external_identifiers: []
     })
     .matchHeader('Authorization', 'from_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       keypair: {
         id: 'from_stored_keypair_id'

--- a/test/commands/connections/list.test.ts
+++ b/test/commands/connections/list.test.ts
@@ -6,10 +6,11 @@ describe('connections:list', () => {
   customTest
     .stdout()
     .mockCryppo()
-    .nock('https://api-sandbox.meeco.me', api => {
+    .nock('https://sandbox.meeco.me/vault', api => {
       api
         .get('/connections')
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+        .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, {
           connections: [
             {

--- a/test/commands/items/create-config.test.ts
+++ b/test/commands/items/create-config.test.ts
@@ -6,7 +6,7 @@ describe('items:create-config', () => {
   customTest
     .stdout()
     .stderr()
-    .nock('https://api-sandbox.meeco.me', mockVault)
+    .nock('https://sandbox.meeco.me/vault', mockVault)
     .run(['items:create-config', 'food', ...testUserAuth, ...testEnvironmentFile])
     .it('builds an item template from an api template name', ctx => {
       const expected = readFileSync(outputFixture('create-config-item.output.yaml'), 'utf-8');
@@ -57,5 +57,6 @@ function mockVault(api) {
       'by_classification[name]': 'esafe_templates'
     })
     .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, response);
 }

--- a/test/commands/items/get.test.ts
+++ b/test/commands/items/get.test.ts
@@ -7,7 +7,7 @@ describe('items:get', () => {
     .stdout()
     .stderr()
     .mockCryppo()
-    .nock('https://api-sandbox.meeco.me', mockVault)
+    .nock('https://sandbox.meeco.me/vault', mockVault)
     .run(['items:get', 'my-item', ...testUserAuth, ...testEnvironmentFile])
     .it('returns an item with all slots decrypted', ctx => {
       const expected = readFileSync(outputFixture('get-item.output.yaml'), 'utf-8');
@@ -56,5 +56,6 @@ function mockVault(api) {
   api
     .get('/items/my-item')
     .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, response);
 }

--- a/test/commands/items/list.test.ts
+++ b/test/commands/items/list.test.ts
@@ -4,10 +4,11 @@ import { customTest, outputFixture, testEnvironmentFile, testUserAuth } from '..
 
 describe('items:list', () => {
   customTest
-    .nock('https://api-sandbox.meeco.me', api =>
+    .nock('https://sandbox.meeco.me/vault', api =>
       api
         .get('/items')
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+        .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, {
           items: [
             {

--- a/test/commands/shares/create-config.test.ts
+++ b/test/commands/shares/create-config.test.ts
@@ -5,7 +5,7 @@ import { customTest, inputFixture, outputFixture, testEnvironmentFile } from '..
 describe('shares:create-config', () => {
   customTest
     .stdout()
-    .nock('https://api-sandbox.meeco.me', mockVault)
+    .nock('https://sandbox.meeco.me/vault', mockVault)
     .run([
       'shares:create-config',
       '-f',
@@ -31,5 +31,6 @@ function mockVault(api) {
   api
     .get('/items/my-item')
     .matchHeader('Authorization', 'from_vault_access')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, response);
 }

--- a/test/commands/shares/create.test.ts
+++ b/test/commands/shares/create.test.ts
@@ -12,8 +12,8 @@ describe('shares:create', () => {
     .stderr()
     .mockCryppo()
     .stub(global, 'Date', sinon.stub().returns(constantDate))
-    .nock('https://api-sandbox.meeco.me', stubVault)
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
     .run(['shares:create', '-c', inputFixture('create-share.input.yaml'), ...testEnvironmentFile])
     .it('can setup sharing between two users', ctx => {
       const expected = readFileSync(outputFixture('create-share.output.yaml'), 'utf-8');
@@ -25,6 +25,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/items/from_user_vault_item_to_share_id')
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       slots: [
         {
@@ -43,6 +44,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -57,6 +59,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'to_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -72,6 +75,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections/from_user_connection_id')
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connection: {
         id: 'from_user_connection_id',
@@ -85,12 +89,14 @@ function stubVault(api: nock.Scope) {
       encryption_space_id: 'from_user_created_encryption_space_id'
     })
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200);
 
   // Fetch connection from the other user's perspective
   api
     .get('/connections/to_user_connection_id')
     .matchHeader('authorization', 'to_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connection: {
         id: 'to_user_connection_id',
@@ -105,6 +111,7 @@ function stubVault(api: nock.Scope) {
       encryption_space_id: 'to_user_encryption_space_id'
     })
     .matchHeader('Authorization', 'to_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {});
 
   api
@@ -126,6 +133,7 @@ function stubVault(api: nock.Scope) {
       ]
     })
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       slots: [
         {
@@ -147,6 +155,7 @@ function stubKeystore(api: nock.Scope) {
       encrypted_serialized_key: `[serialized][encrypted]randomly_generated_key[with from_user_key_encryption_key]`
     })
     .matchHeader('Authorization', 'from_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       encryption_space_data_encryption_key: {
         encryption_space_id: 'from_user_created_encryption_space_id'
@@ -162,6 +171,7 @@ function stubKeystore(api: nock.Scope) {
       key_metadata: { key_type: 'AES-GCM' }
     })
     .matchHeader('Authorization', 'from_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       shared_key: {}
     });
@@ -170,6 +180,7 @@ function stubKeystore(api: nock.Scope) {
   api
     .get('/keypairs/to_user_keystore_keypair_id')
     .matchHeader('Authorization', 'to_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       keypair: {
         public_key: 'my_public_key',
@@ -182,11 +193,12 @@ function stubKeystore(api: nock.Scope) {
     .post('/shared_keys/from_user_encryption_space_id/claim_key', {
       public_key: 'my_public_key',
       request_signature:
-        '[serialized]https://keystore-sandbox.meeco.me/shared_keys/from_user_encryption_space_id/claim_key--request-timestamp=1970-01-01T00:00:00.000Z[signed ' +
+        '[serialized]https://sandbox.meeco.me/keystore/shared_keys/from_user_encryption_space_id/claim_key--request-timestamp=1970-01-01T00:00:00.000Z[signed ' +
         'with encrypted_shared_dek[decrypted with ' +
         'to_user_key_encryption_key]]'
     })
     .matchHeader('authorization', 'to_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       shared_key_claimed: {
         serialized_shared_key: 'encrypted_shared_dek'
@@ -202,6 +214,7 @@ function stubKeystore(api: nock.Scope) {
         'to_user_key_encryption_key]'
     })
     .matchHeader('Authorization', 'to_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       encryption_space_data_encryption_key: {
         encryption_space_id: 'to_user_encryption_space_id'

--- a/test/commands/shares/get.test.ts
+++ b/test/commands/shares/get.test.ts
@@ -8,8 +8,8 @@ describe('shares:get', () => {
     .stdout()
     .stderr()
     .mockCryppo()
-    .nock('https://api-sandbox.meeco.me', mockVault)
-    .nock('https://keystore-sandbox.meeco.me', mockKeystore)
+    .nock('https://sandbox.meeco.me/vault', mockVault)
+    .nock('https://sandbox.meeco.me/keystore', mockKeystore)
     .run(['shares:get', ...testUserAuth, ...testEnvironmentFile, 'share_1'])
     .it('lists the decrypted slots from a shared item', ctx => {
       const expected = readFileSync(outputFixture('get-shares.output.yaml'), 'utf-8');
@@ -21,6 +21,7 @@ function mockVault(api: nock.Scope) {
   api
     .get('/shares/share_1')
     .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       shares: [
         {
@@ -59,6 +60,7 @@ function mockKeystore(api: nock.Scope) {
   api
     .get('/encryption_spaces/es_1')
     .matchHeader('Authorization', 'a2V5c3RvcmVfYXV0aF90b2tlbg==')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       encryption_space_data_encryption_key: {
         serialized_data_encryption_key: 'secret_shared_key'

--- a/test/commands/shares/get.test.ts
+++ b/test/commands/shares/get.test.ts
@@ -28,7 +28,11 @@ function mockVault(api: nock.Scope) {
           id: 'sh_1',
           connection_id: 'con_1',
           shareable_id: 'it_1',
-          encryption_space_id: 'es_1'
+          encryption_space_id: 'es_1',
+          encrypted_values: {
+            sl_1: 'encrypted_fluffy',
+            sl_2: 'encrypted_12'
+          }
         }
       ],
       items: [
@@ -44,13 +48,15 @@ function mockVault(api: nock.Scope) {
           id: 'sl_1',
           label: 'name',
           encrypted: true,
-          encrypted_value: 'encrypted_fluffy'
+          // The API will return null as the encrypted_values on the share are to be used
+          encrypted_value: null
         },
         {
           id: 'sl_2',
           label: 'age',
           encrypted: true,
-          encrypted_value: 'encrypted_12'
+          // The API will return null as the encrypted_values on the share are to be used
+          encrypted_value: null
         }
       ]
     });

--- a/test/commands/shares/info.test.ts
+++ b/test/commands/shares/info.test.ts
@@ -8,8 +8,8 @@ describe('shares:info', () => {
     .stdout()
     .stderr()
     .mockCryppo()
-    .nock('https://api-sandbox.meeco.me', stubVault)
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
     .run(['shares:info', '-c', inputFixture('info-share.input.yaml'), ...testEnvironmentFile])
     .it('shows share information between two users', ctx => {
       const expected = readFileSync(outputFixture('info-share.output.yaml'), 'utf-8');
@@ -21,6 +21,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'from_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -35,6 +36,7 @@ function stubVault(api: nock.Scope) {
   api
     .get('/connections')
     .matchHeader('Authorization', 'to_user_vault_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       connections: [
         {
@@ -51,6 +53,7 @@ function stubKeystore(api: nock.Scope) {
   api
     .get('/encryption_spaces/from_user_shared_encryption_space_id')
     .matchHeader('Authorization', 'from_user_keystore_access_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       encryption_space_data_encryption_key: {
         serialized_data_encryption_key: 'serialized_shared_data_encryption_key'

--- a/test/commands/shares/list.test.ts
+++ b/test/commands/shares/list.test.ts
@@ -6,10 +6,11 @@ describe('shares:list', () => {
   customTest
     .stdout()
     .stderr()
-    .nock('https://api-sandbox.meeco.me', api => {
+    .nock('https://sandbox.meeco.me/vault', api => {
       api
         .get('/shares')
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+        .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, {
           shares: [
             {

--- a/test/commands/templates/info.test.ts
+++ b/test/commands/templates/info.test.ts
@@ -6,7 +6,7 @@ describe('templates:info', () => {
   customTest
     .stderr()
     .stdout()
-    .nock('https://api-sandbox.meeco.me', api => {
+    .nock('https://sandbox.meeco.me/vault', api => {
       api
         .get('/item_templates')
         .query({
@@ -14,6 +14,7 @@ describe('templates:info', () => {
           'by_classification[name]': 'esafe_templates'
         })
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+        .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, response);
     })
     .run(['templates:info', 'drink', ...testUserAuth, ...testEnvironmentFile])

--- a/test/commands/templates/list.test.ts
+++ b/test/commands/templates/list.test.ts
@@ -6,7 +6,7 @@ describe('templates:list', () => {
   customTest
     .stderr()
     .stdout()
-    .nock('https://api-sandbox.meeco.me', api => {
+    .nock('https://sandbox.meeco.me/vault', api => {
       api
         .get('/item_templates')
         .query({
@@ -14,6 +14,7 @@ describe('templates:list', () => {
           'by_classification[name]': 'esafe_templates'
         })
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+        .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, response);
     })
     .run(['templates:list', ...testUserAuth, ...testEnvironmentFile])

--- a/test/commands/users/create.test.ts
+++ b/test/commands/users/create.test.ts
@@ -7,8 +7,8 @@ import { customTest, outputFixture, testEnvironmentFile } from '../../test-helpe
 
 describe('meeco users:create', () => {
   customTest
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
-    .nock('https://api-sandbox.meeco.me', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
     .mockCryppo()
     .mockSRP()
     .stderr()
@@ -63,6 +63,7 @@ function stubKeystore(api: Nock.Scope) {
   api
     .get('/external_admission_tokens')
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       external_admission_token: <ExternalAdmissionTokens>{
         passphrase_store_admission_token: 'passphrase_token',
@@ -75,6 +76,7 @@ function stubKeystore(api: Nock.Scope) {
       serialized_key_encryption_key: `[serialized][encrypted]randomly_generated_key[with derived_key_123.asupersecretpassphrase]`
     })
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       key_encryption_key: {
         id: 'key_encryption_key_id'
@@ -86,6 +88,7 @@ function stubKeystore(api: Nock.Scope) {
       serialized_data_encryption_key: `[serialized][encrypted]randomly_generated_key[with randomly_generated_key]`
     })
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       data_encryption_key: {
         id: 'data_encryption_key_id'
@@ -100,6 +103,7 @@ function stubKeystore(api: Nock.Scope) {
       external_identifiers: [VAULT_PAIR_EXTERNAL_IDENTIFIER]
     })
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {});
 }
 
@@ -123,5 +127,6 @@ function stubVault(api: Nock.Scope) {
       }
     })
     .matchHeader('Authorization', '[decrypted]encrypted_vault_session_string--PRIVATE_KEY--12324')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {});
 }

--- a/test/commands/users/get.test.ts
+++ b/test/commands/users/get.test.ts
@@ -7,8 +7,8 @@ import { customTest, inputFixture, outputFixture, testEnvironmentFile } from '..
 
 describe('meeco users:get', () => {
   customTest
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
-    .nock('https://api-sandbox.meeco.me', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
     .mockCryppo()
     .mockSRP()
     .stderr()
@@ -20,8 +20,8 @@ describe('meeco users:get', () => {
     });
 
   customTest
-    .nock('https://keystore-sandbox.meeco.me', stubKeystore)
-    .nock('https://api-sandbox.meeco.me', stubVault)
+    .nock('https://sandbox.meeco.me/keystore', stubKeystore)
+    .nock('https://sandbox.meeco.me/vault', stubVault)
     .mockCryppo()
     .mockSRP()
     .stderr()
@@ -66,6 +66,7 @@ function stubKeystore(api: Nock.Scope) {
   api
     .get('/key_encryption_key')
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       key_encryption_key: {
         serialized_key_encryption_key: `key_encryption_key`
@@ -74,6 +75,7 @@ function stubKeystore(api: Nock.Scope) {
   api
     .get('/data_encryption_keys/data_encryption_key_id')
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       data_encryption_key: {
         serialized_data_encryption_key: `data_encryption_key`
@@ -82,6 +84,7 @@ function stubKeystore(api: Nock.Scope) {
   api
     .get('/keypairs/external_id/auth')
     .matchHeader('Authorization', 'keystore_auth_token')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       keypair: {
         public_key: '--PUBLIC_KEY--ABCD',

--- a/test/fixtures/inputs/test-environment.input.yaml
+++ b/test/fixtures/inputs/test-environment.input.yaml
@@ -1,9 +1,12 @@
 vault:
-  url: https://api-sandbox.meeco.me
+  url: https://sandbox.meeco.me/vault
+  subscription_key: environment_subscription_key
 keystore:
-  url: https://keystore-sandbox.meeco.me
-  provider_api_key: MyProviderApiKey
+  url: https://sandbox.meeco.me/keystore
+  subscription_key: environment_subscription_key
 downloader:
   url: https://downloader-esafe-test.meeco.me
+  subscription_key: environment_subscription_key
 passphrase:
   url: https://passphrasestore-esafe-test.meeco.me
+  subscription_key: environment_subscription_key


### PR DESCRIPTION
Also moves api construction to factories to cleanup the setting of auth, baseurl and keys a bit.

All unit tests now expect a subscription key.
Docs poitn to the correct api host and have subscription keys.