### PR TITLE
Add default version and component headers to all requests

### DIFF
--- a/src/util/api-factory.ts
+++ b/src/util/api-factory.ts
@@ -3,6 +3,8 @@ import * as Keystore from '@meeco/meeco-keystore-sdk';
 import { AuthConfig } from '../configs/auth-config';
 import { IEnvironment } from '../models/environment';
 
+const X_MEECO_API_VERSION = '2.0.0';
+
 /**
  * User authentication token for the given API or the entire user with tokens
  */
@@ -93,7 +95,7 @@ const keystoreAPI = (api: KeystoreAPIName, environment: IEnvironment, userAuth: 
             keystoreAPIKeys(environment, userAuth),
             environment.keystore.url,
             {
-              X_MEECO_API_VERSION: '3.0.0',
+              X_MEECO_API_VERSION: '2.0.0',
               X_MEECO_API_COMPONENT: 'keystore'
             },
             args
@@ -119,7 +121,7 @@ const vaultAPI = (api: VaultAPIName, environment: IEnvironment, userAuth: UserAu
             vaultAPIKeys(environment, userAuth),
             environment.vault.url,
             {
-              X_MEECO_API_VERSION: '3.0.0',
+              X_MEECO_API_VERSION,
               X_MEECO_API_COMPONENT: 'vault'
             },
             args

--- a/src/util/api-factory.ts
+++ b/src/util/api-factory.ts
@@ -66,7 +66,15 @@ const callApiWithDefaultHeaders = (
     ...fetchOptions.headers
   };
   args[argsCount - 1] = fetchOptions;
-  return apiMethod.call(apiInstance, ...args);
+  return apiMethod.call(apiInstance, ...args).catch(err => {
+    if (err.status === 426) {
+      throw new Error(
+        'The API returned 426 and therefore does not support this version of the CLI. Please check for an update to the Meeco CLI.'
+      );
+    } else {
+      throw err;
+    }
+  });
 };
 
 /**

--- a/src/util/api-factory.ts
+++ b/src/util/api-factory.ts
@@ -45,24 +45,80 @@ const vaultAPIKeys = (environment: IEnvironment, userAuth: UserAuth) => (name: s
     'Authorization': vaultToken(userAuth)
   }[name]);
 
+const callApiWithDefaultHeaders = (
+  sdk: any,
+  api: string,
+  apiMethodName: string | symbol | number,
+  apiKey: string | ((name: string) => string),
+  basePath: string,
+  defaultHeaders: { [key: string]: string },
+  args: any[]
+) => {
+  const apiInstance = new sdk[api]({
+    apiKey,
+    basePath
+  });
+  const apiMethod = apiInstance[apiMethodName];
+  const argsCount = apiMethod.length;
+  const fetchOptions = args[argsCount - 1] || {};
+  fetchOptions.headers = {
+    ...defaultHeaders,
+    ...fetchOptions.headers
+  };
+  args[argsCount - 1] = fetchOptions;
+  return apiMethod.call(apiInstance, ...args);
+};
+
 /**
  * Helper for constructing instances of Keystore apis with all the required auth params
  */
 const keystoreAPI = (api: KeystoreAPIName, environment: IEnvironment, userAuth: UserAuth) => {
-  return new Keystore[api]({
-    apiKey: keystoreAPIKeys(environment, userAuth),
-    basePath: environment.keystore.url
-  }) as InstanceType<typeof Keystore[typeof api]>;
+  return new Proxy(
+    {},
+    {
+      get(target, apiMethodName) {
+        return (...args) =>
+          callApiWithDefaultHeaders(
+            Keystore,
+            api,
+            apiMethodName,
+            keystoreAPIKeys(environment, userAuth),
+            environment.keystore.url,
+            {
+              X_MEECO_API_VERSION: '3.0.0',
+              X_MEECO_API_COMPONENT: 'keystore'
+            },
+            args
+          );
+      }
+    }
+  ) as InstanceType<typeof Keystore[typeof api]>;
 };
 
 /**
  * Helper for constructing instances of Vault apis with all the required auth params
  */
 const vaultAPI = (api: VaultAPIName, environment: IEnvironment, userAuth: UserAuth) => {
-  return new Vault[api]({
-    apiKey: vaultAPIKeys(environment, userAuth),
-    basePath: environment.vault.url
-  }) as InstanceType<typeof Vault[typeof api]>;
+  return new Proxy(
+    {},
+    {
+      get(target, apiMethodName) {
+        return (...args) =>
+          callApiWithDefaultHeaders(
+            Vault,
+            api,
+            apiMethodName,
+            vaultAPIKeys(environment, userAuth),
+            environment.vault.url,
+            {
+              X_MEECO_API_VERSION: '3.0.0',
+              X_MEECO_API_COMPONENT: 'vault'
+            },
+            args
+          );
+      }
+    }
+  ) as InstanceType<typeof Vault[typeof api]>;
 };
 
 /**

--- a/test/util/api-factory.test.ts
+++ b/test/util/api-factory.test.ts
@@ -12,7 +12,7 @@ describe('API Factories', () => {
         .get('/keypairs/my-id')
         .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
         .matchHeader('Authorization', 'my-keystore-token')
-        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_VERSION', '2.0.0')
         .matchHeader('X_MEECO_API_COMPONENT', 'keystore')
         .reply(200, {
           status: 'ok'
@@ -37,7 +37,7 @@ describe('API Factories', () => {
         .get('/keypairs/my-id')
         .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
         .matchHeader('Authorization', 'my-keystore-token')
-        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_VERSION', '2.0.0')
         .matchHeader('X_MEECO_API_COMPONENT', 'keystore')
         .matchHeader('X_MY_CUSTOM_HEADER', 'foo')
         .reply(200, {
@@ -100,7 +100,7 @@ describe('API Factories', () => {
         .get('/items/my-id')
         .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
         .matchHeader('Authorization', 'my-vault-token')
-        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_VERSION', '2.0.0')
         .matchHeader('X_MEECO_API_COMPONENT', 'vault')
         .reply(200, {
           status: 'ok'
@@ -125,7 +125,7 @@ describe('API Factories', () => {
         .get('/items/my-id')
         .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
         .matchHeader('Authorization', 'my-vault-token')
-        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_VERSION', '2.0.0')
         .matchHeader('X_MEECO_API_COMPONENT', 'vault')
         .matchHeader('X_MY_CUSTOM_HEADER', 'bar')
         .reply(200, {

--- a/test/util/api-factory.test.ts
+++ b/test/util/api-factory.test.ts
@@ -1,0 +1,122 @@
+import { expect } from '@oclif/test';
+import * as nock from 'nock';
+import { keystoreAPIFactory, vaultAPIFactory } from '../../src/util/api-factory';
+
+describe('API Factories', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+  describe('keystoreAPIFactory', () => {
+    it('adds the required authorization headers and default version headers to request methods', async () => {
+      nock('https://meeco-keystore.example.com/')
+        .get('/keypairs/my-id')
+        .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
+        .matchHeader('Authorization', 'my-keystore-token')
+        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_COMPONENT', 'keystore')
+        .reply(200, {
+          status: 'ok'
+        });
+      const apiFactory = keystoreAPIFactory(<any>{
+        keystore: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-keystore.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        keystore_access_token: 'my-keystore-token'
+      });
+      const result = await forUser.KeypairApi.keypairsIdGet('my-id');
+      expect(result).to.eql({
+        status: 'ok'
+      });
+    });
+
+    it('mixes any user-defined headers with the default ones', async () => {
+      nock('https://meeco-keystore.example.com/')
+        .get('/keypairs/my-id')
+        .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
+        .matchHeader('Authorization', 'my-keystore-token')
+        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_COMPONENT', 'keystore')
+        .matchHeader('X_MY_CUSTOM_HEADER', 'foo')
+        .reply(200, {
+          status: 'ok'
+        });
+      const apiFactory = keystoreAPIFactory(<any>{
+        keystore: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-keystore.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        keystore_access_token: 'my-keystore-token'
+      });
+      const result = await forUser.KeypairApi.keypairsIdGet('my-id', {
+        headers: {
+          X_MY_CUSTOM_HEADER: 'foo'
+        }
+      });
+      expect(result).to.eql({
+        status: 'ok'
+      });
+    });
+  });
+
+  describe('vaultAPIFactory', () => {
+    it('adds the required authorization headers and default version headers to request methods', async () => {
+      nock('https://meeco-vault.example.com/')
+        .get('/items/my-id')
+        .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
+        .matchHeader('Authorization', 'my-vault-token')
+        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_COMPONENT', 'vault')
+        .reply(200, {
+          status: 'ok'
+        });
+      const apiFactory = vaultAPIFactory(<any>{
+        vault: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-vault.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        vault_access_token: 'my-vault-token'
+      });
+      const result = await forUser.ItemApi.itemsIdGet('my-id');
+      expect(result).to.eql({
+        status: 'ok'
+      });
+    });
+
+    it('mixes any user-defined headers with the default ones', async () => {
+      nock('https://meeco-vault.example.com/')
+        .get('/items/my-id')
+        .matchHeader('Meeco-Subscription-Key', 'my_sub_key')
+        .matchHeader('Authorization', 'my-vault-token')
+        .matchHeader('X_MEECO_API_VERSION', '3.0.0')
+        .matchHeader('X_MEECO_API_COMPONENT', 'vault')
+        .matchHeader('X_MY_CUSTOM_HEADER', 'bar')
+        .reply(200, {
+          status: 'ok'
+        });
+      const apiFactory = vaultAPIFactory(<any>{
+        vault: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-vault.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        vault_access_token: 'my-vault-token'
+      });
+      const result = await forUser.ItemApi.itemsIdGet('my-id', {
+        headers: {
+          X_MY_CUSTOM_HEADER: 'bar'
+        }
+      });
+      expect(result).to.eql({
+        status: 'ok'
+      });
+    });
+  });
+});

--- a/test/util/api-factory.test.ts
+++ b/test/util/api-factory.test.ts
@@ -61,6 +61,37 @@ describe('API Factories', () => {
         status: 'ok'
       });
     });
+
+    it('captures api version issues and throws a special error', async () => {
+      nock('https://meeco-keystore.example.com/')
+        .get('/keypairs/my-id')
+        .reply(426);
+      const apiFactory = keystoreAPIFactory(<any>{
+        keystore: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-keystore.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        keystore_access_token: 'my-keystore-token'
+      });
+      let error;
+      try {
+        const result = await forUser.KeypairApi.keypairsIdGet('my-id', {
+          headers: {
+            X_MY_CUSTOM_HEADER: 'foo'
+          }
+        });
+        expect(result).to.eql({
+          status: 'ok'
+        });
+      } catch (err) {
+        error = err;
+      }
+      expect(error.message).to.include(
+        'The API returned 426 and therefore does not support this version of the CLI. Please check for an update to the Meeco CLI'
+      );
+    });
   });
 
   describe('vaultAPIFactory', () => {
@@ -117,6 +148,37 @@ describe('API Factories', () => {
       expect(result).to.eql({
         status: 'ok'
       });
+    });
+
+    it('captures api version issues and throws a special error', async () => {
+      nock('https://meeco-vault.example.com/')
+        .get('/items/my-id')
+        .reply(426);
+      const apiFactory = vaultAPIFactory(<any>{
+        vault: {
+          subscription_key: 'my_sub_key',
+          url: 'https://meeco-vault.example.com'
+        }
+      });
+      const forUser = apiFactory(<any>{
+        vault_access_token: 'my-vault-token'
+      });
+      let error;
+      try {
+        const result = await forUser.ItemApi.itemsIdGet('my-id', {
+          headers: {
+            X_MY_CUSTOM_HEADER: 'foo'
+          }
+        });
+        expect(result).to.eql({
+          status: 'ok'
+        });
+      } catch (err) {
+        error = err;
+      }
+      expect(error.message).to.include(
+        'The API returned 426 and therefore does not support this version of the CLI. Please check for an update to the Meeco CLI'
+      );
     });
   });
 });


### PR DESCRIPTION
This PR sends up the version headers `X_MEECO_API_VERSION` and `X_MEECO_API_COMPONENT` with every request.

It also will throw a special exception when the API returns a `426` (update required):

```
Error: The API returned 426 and therefore does not support this version of the CLI. Please check for an update to the Meeco CLI.
```

Note: I've used `3.0.0` as that is what was discussed but I do see the version from the API is currently returning `2.0.0`

