### PR TITLE
Share Item takes fromUser credentials and connectionId

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -105,7 +105,7 @@ If you would prefer to provide a configuration file with your credentials, suppl
 
 1. Ensure users are connected first (see above)
 2. Select an item from user 1 to share to user 2
-3. Create the share template: `meeco shares:create-config --from .user.yaml --to .user_2.yaml -i <item_id_to_share> > .share_config.yaml`
+3. Create the share template: `meeco shares:create-config --from .user.yaml --connectionId <connection_id_to_share_to> -i <item_id_to_share> > .share_config.yaml`
 4. Create the share: `meeco shares:create -c .share_config.yaml`
 
 This will setup a private encryption space between the two users (if it does not exist already) and then share the item.
@@ -399,10 +399,10 @@ USAGE
   $ meeco shares:create-config
 
 OPTIONS
-  -e, --environment=environment  [default: .environment.yaml] environment config file
-  -f, --from=from                (required) User config file for the 'from' user
-  -i, --itemId=itemId            (required) Item id of the 'from' user to share with the 'to' use
-  -t, --to=to                    (required) User config file for the 'to' user
+  -c, --connectionId=connectionId  (required) Connection id for the 'to' user
+  -e, --environment=environment    [default: .environment.yaml] environment config file
+  -f, --from=from                  (required) User config file for the 'from' user
+  -i, --itemId=itemId              (required) Item id of the 'from' user to share with the 'to' use
 ```
 
 _See code: [src/commands/shares/create-config.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/create-config.ts)_
@@ -635,14 +635,9 @@ spec:
 kind: Share
 metadata:
 spec:
-  item_id: <string> # id of the item to be shared (all slots will be shard)
+  item_id: <string> # id of the item to be shared (all slots will be shared)
+  connection_id: <string> # id of the connection the item will be shared with
   from:
-    keystore_access_token: <string>
-    vault_access_token: <string>
-    passphrase_derived_key: <string> # url-safe base64
-    key_encryption_key: <string> # url-safe base64
-    data_encryption_key: <string> # url-safe base64
-  to:
     keystore_access_token: <string>
     vault_access_token: <string>
     passphrase_derived_key: <string> # url-safe base64

--- a/packages/cli/src/commands/shares/create.ts
+++ b/packages/cli/src/commands/shares/create.ts
@@ -30,7 +30,7 @@ export default class SharesCreate extends MeecoCommand {
       }
 
       const service = new ShareService(environment, this.updateStatus);
-      const result = await service.shareItem(share.from, share.to, share.itemId);
+      const result = await service.shareItem(share.from, share.connectionId, share.itemId);
       this.printYaml(result);
     } catch (err) {
       await this.handleException(err);

--- a/packages/cli/src/commands/shares/info.ts
+++ b/packages/cli/src/commands/shares/info.ts
@@ -34,14 +34,11 @@ export default class SharesInfo extends MeecoCommand {
         share.from,
         share.to,
         environment,
-        this.log
+        this.updateStatus
       );
-      const result = await service.fetchSharedEncryptionSpace(
-        share.from,
-        share.to,
-        fromUserConnection,
-        toUserConnection
-      );
+
+      const result = await service.fetchSharedEncryptionSpace(share.from, fromUserConnection);
+      result.to_user_connection_id = toUserConnection.id;
       this.printYaml(result);
     } catch (err) {
       await this.handleException(err);

--- a/packages/cli/src/configs/connection-config.ts
+++ b/packages/cli/src/configs/connection-config.ts
@@ -12,8 +12,8 @@ interface IConnectionSpec {
 export class ConnectionConfig {
   static kind = 'Connection';
 
-  public readonly to: AuthConfig;
   public readonly from: AuthConfig;
+  public readonly to: AuthConfig;
   public readonly options: IConnectionMetadata;
 
   constructor(data: { to: AuthConfig; from: AuthConfig; options: IConnectionMetadata }) {

--- a/packages/cli/src/configs/share-config.ts
+++ b/packages/cli/src/configs/share-config.ts
@@ -5,14 +5,14 @@ import { IYamlConfig } from './yaml-config';
 
 interface IShareSpec {
   item_id: string;
-  to: AuthConfig;
+  connection_id: string;
   from: AuthConfig;
 }
 
 export class ShareConfig {
   static kind = 'Share';
 
-  public readonly to: AuthConfig;
+  public readonly connectionId: string;
   public readonly from: AuthConfig;
   public readonly itemId: string;
   public readonly options: {};
@@ -20,7 +20,7 @@ export class ShareConfig {
   constructor(data: ShareConfig) {
     this.itemId = data.itemId;
     this.from = data.from;
-    this.to = data.to;
+    this.connectionId = data.connectionId;
     this.options = data.options;
   }
 
@@ -33,7 +33,7 @@ export class ShareConfig {
 
     return new ShareConfig({
       from: AuthConfig.fromMetadata(yamlConfigObj.spec.from),
-      to: AuthConfig.fromMetadata(yamlConfigObj.spec.to),
+      connectionId: yamlConfigObj.spec.connection_id,
       itemId: yamlConfigObj.spec.item_id,
       options: yamlConfigObj.metadata
     });
@@ -52,7 +52,7 @@ export class ShareConfig {
 
   static encodeFromUsersWithItem(
     from: AuthConfig,
-    to: AuthConfig,
+    connectionId: string,
     itemId: string
   ): IYamlConfig<any, IShareSpec> {
     return {
@@ -60,8 +60,8 @@ export class ShareConfig {
       metadata: {},
       spec: {
         item_id: itemId,
-        from,
-        to
+        connection_id: connectionId,
+        from
       }
     };
   }

--- a/packages/cli/test/commands/shares/create-config.test.ts
+++ b/packages/cli/test/commands/shares/create-config.test.ts
@@ -10,8 +10,8 @@ describe('shares:create-config', () => {
       'shares:create-config',
       '-f',
       inputFixture('connection-from.input.yaml'),
-      '-t',
-      inputFixture('connection-to.input.yaml'),
+      '-c',
+      'connection-id',
       '-i',
       'my-item',
       ...testEnvironmentFile
@@ -39,4 +39,10 @@ function mockVault(api) {
     .matchHeader('Authorization', 'from_vault_access')
     .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, response);
+
+  api
+    .get('/connections/connection-id')
+    .matchHeader('Authorization', 'from_vault_access')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
+    .reply(200, { connection: { id: 'connection-id' } });
 }

--- a/packages/cli/test/commands/shares/create.test.ts
+++ b/packages/cli/test/commands/shares/create.test.ts
@@ -47,36 +47,6 @@ function stubVault(api: nock.Scope) {
       thumbnails: []
     });
 
-  api
-    .get('/connections')
-    .matchHeader('Authorization', 'from_user_vault_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      connections: [
-        {
-          id: 'from_user_connection_id',
-          encryption_space_id: null, // not setup yet
-          other_user_connection_public_key: 'to_user_public_key',
-          user_id: 'to_user_id'
-        }
-      ]
-    });
-
-  api
-    .get('/connections')
-    .matchHeader('Authorization', 'to_user_vault_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      connections: [
-        {
-          id: 'to_user_connection_id',
-          public_key: 'to_user_public_key',
-          encryption_space_id: null, // not setup yet
-          user_id: 'from_user_id'
-        }
-      ]
-    });
-
   // Fetch connection
   api
     .get('/connections/from_user_connection_id')
@@ -85,7 +55,9 @@ function stubVault(api: nock.Scope) {
     .reply(200, {
       connection: {
         id: 'from_user_connection_id',
-        other_user_connection_public_key: 'to_user_public_key'
+        encryption_space_id: null, // not setup yet
+        other_user_connection_public_key: 'to_user_public_key',
+        user_id: 'to_user_id'
       }
     });
 
@@ -97,28 +69,6 @@ function stubVault(api: nock.Scope) {
     .matchHeader('Authorization', 'from_user_vault_access_token')
     .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200);
-
-  // Fetch connection from the other user's perspective
-  api
-    .get('/connections/to_user_connection_id')
-    .matchHeader('authorization', 'to_user_vault_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      connection: {
-        id: 'to_user_connection_id',
-        key_store_keypair_id: 'to_user_keystore_keypair_id',
-        other_user_connection_encryption_space_id: 'from_user_encryption_space_id'
-      }
-    });
-
-  // Create a new encryption space for the connection
-  api
-    .post('/connections/to_user_connection_id/encryption_space', {
-      encryption_space_id: 'to_user_encryption_space_id'
-    })
-    .matchHeader('Authorization', 'to_user_vault_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {});
 
   api
     .post('/shares', {
@@ -175,50 +125,5 @@ function stubKeystore(api: nock.Scope) {
     .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, {
       shared_key: {}
-    });
-
-  // Fetch the key pair to decrypt the shared DEK with
-  api
-    .get('/keypairs/to_user_keystore_keypair_id')
-    .matchHeader('Authorization', 'to_user_keystore_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      keypair: {
-        public_key: 'my_public_key',
-        encrypted_serialized_key: 'encrypted_shared_dek'
-      }
-    });
-
-  // Claim the shared DEK with signed url
-  api
-    .post('/shared_keys/from_user_encryption_space_id/claim_key', {
-      public_key: 'my_public_key',
-      request_signature:
-        '[serialized]https://sandbox.meeco.me/keystore/shared_keys/from_user_encryption_space_id/claim_key--request-timestamp=1970-01-01T00:00:00.000Z[signed ' +
-        'with encrypted_shared_dek[decrypted with ' +
-        'to_user_key_encryption_key]]'
-    })
-    .matchHeader('authorization', 'to_user_keystore_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      shared_key_claimed: {
-        serialized_shared_key: 'encrypted_shared_dek'
-      }
-    });
-
-  // Create encryption space with the re-encrypted key
-  api
-    .post('/encryption_spaces', {
-      encrypted_serialized_key:
-        '[serialized][encrypted][decrypted]encrypted_shared_dekencrypted_shared_dek[decrypted ' +
-        'with to_user_key_encryption_key][with ' +
-        'to_user_key_encryption_key]'
-    })
-    .matchHeader('Authorization', 'to_user_keystore_access_token')
-    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-    .reply(200, {
-      encryption_space_data_encryption_key: {
-        encryption_space_id: 'to_user_encryption_space_id'
-      }
     });
 }

--- a/packages/cli/test/e2e.sh
+++ b/packages/cli/test/e2e.sh
@@ -20,7 +20,8 @@ run connections:create -c .connection_Alice_Bob.yaml
 echo "List 'Alice's items and prepare one for sharing"
 run items:list -a .Alice.yaml
 itemid=`run items:list -a .Alice.yaml | awk '/^  - id: / {print $3}'`
-run shares:create-config --from .Alice.yaml --to .Bob.yaml -i $itemid > .share_Alice_Bob.yaml
+connectionId=`run connections:list -a .Alice.yaml | awk '/^    id: / {print $2}'`
+run shares:create-config --from .Alice.yaml --connectionId $connectionId -i $itemid > .share_Alice_Bob.yaml
 echo "Share the card to 'Bob'"
 run shares:create -c .share_Alice_Bob.yaml
 echo "Fetch the shared card as 'Bob'"

--- a/packages/cli/test/fixtures/inputs/create-share.input.yaml
+++ b/packages/cli/test/fixtures/inputs/create-share.input.yaml
@@ -2,11 +2,7 @@ kind: Share
 metadata:
 spec:
   item_id: from_user_vault_item_to_share_id
-  to:
-    keystore_access_token: to_user_keystore_access_token
-    vault_access_token: to_user_vault_access_token
-    data_encryption_key: dG9fdXNlcl9kYXRhX2VuY3J5cHRpb25fa2V5
-    key_encryption_key: dG9fdXNlcl9rZXlfZW5jcnlwdGlvbl9rZXk=
+  connection_id: from_user_connection_id
   from:
     keystore_access_token: from_user_keystore_access_token
     vault_access_token: from_user_vault_access_token

--- a/packages/cli/test/fixtures/outputs/create-config-share.output.yaml
+++ b/packages/cli/test/fixtures/outputs/create-config-share.output.yaml
@@ -2,6 +2,7 @@ kind: Share
 metadata: {}
 spec:
   item_id: my-item
+  connection_id: connection-id
   from:
     secret: 1.from.secret
     keystore_access_token: from_keystore_access
@@ -9,10 +10,3 @@ spec:
     data_encryption_key: bXlfZ2VuZXJhdGVkX2Rlaw==
     key_encryption_key: w7wIfRkfIVZWFcOaCUE7dsKkw6fDqnPCqnR5AsOyw6o=
     passphrase_derived_key: BsKhFEfDtTfDscK6PMOrwr3DiToiwrFbJ2V4OMO7wqFmw55Q
-  to:
-    secret: 1.to.secret
-    keystore_access_token: to_keystore_access
-    vault_access_token: to_vault_access
-    data_encryption_key: dG9fZGVr
-    key_encryption_key: dG9fa2Vr
-    passphrase_derived_key: dG9fcGFzc3BocmFzZV9kZXJpdmVk

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
+    "declaration": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"]

--- a/packages/sdk/src/models/encryption-space-data.ts
+++ b/packages/sdk/src/models/encryption-space-data.ts
@@ -3,17 +3,17 @@ import { EncryptionKey } from './encryption-key';
 export class EncryptionSpaceData {
   static readonly kind = 'EncryptionSpace';
 
-  to_user_connection_id: string;
   from_user_connection_id: string;
+  to_user_connection_id?: string;
   shared_data_encryption_key?: EncryptionKey;
 
   constructor(config: {
-    to_user_connection_id: string;
     from_user_connection_id: string;
+    to_user_connection_id?: string;
     shared_data_encryption_key?: EncryptionKey;
   }) {
-    this.to_user_connection_id = config.to_user_connection_id;
     this.from_user_connection_id = config.from_user_connection_id;
+    this.to_user_connection_id = config.to_user_connection_id;
     this.shared_data_encryption_key = config.shared_data_encryption_key;
   }
 

--- a/packages/sdk/src/util/find-connection-between.ts
+++ b/packages/sdk/src/util/find-connection-between.ts
@@ -38,3 +38,20 @@ export async function findConnectionBetween(
 
   return { fromUserConnection, toUserConnection };
 }
+
+export async function fetchConnectionWithId(
+  user: AuthData,
+  connectionId: string,
+  environment: Environment,
+  log: (message: string) => void
+) {
+  log('Fetching user connection');
+  const response = await connectionApi(user, environment).connectionsIdGet(connectionId);
+  const connection = response.connection;
+
+  if (!connection || !connection.id) {
+    throw new Error(`Conncetion ${connectionId} not found.`);
+  }
+
+  return connection;
+}


### PR DESCRIPTION
Just like with connections we need SDK API that does not require receiving user's credentials.
Existing `shareItem` method was changed. Now instead of second user's credentials it takes `connectionId` that can easily can be fetched by using `meeco connections:list`